### PR TITLE
Small Fix for Merchants/Trainers

### DIFF
--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,7 +41,7 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    ﻿if (npc.AIData == null || (npc.BuySellServiceFlag == 0 && npc.AIData.MaximumTrainingLevel == 0))
+                    ﻿if (npc.AIData == null || (Npc.BuySellServiceFlag == 0 && npc.Teaches == 0))
                     {
                         npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
                     }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,7 +41,7 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    ﻿if (npc.AIData == null || (npc.BuySellServices == 0 && npc.MaximumTrainingLevel == 0))
+                    ﻿if (npc.AIData == null || (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0))
                     {
                         npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
                     }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,7 +41,10 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
+                    ﻿if (npc.AIData == null || (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0))
+                    {
+                        npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
+                    }
                 }
             }
         }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,7 +41,7 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    ﻿if (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0)
+                    ﻿if (npc.AIData != null && npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0)
                     {
                         npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
                     }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,10 +41,10 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    //﻿if (npc.AIData == null || (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0))
-                    //{
-                    //    npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
-                    //}
+                    ﻿if (npc.AIData == null || (npc.BuySellServiceFlag == 0 && npc.AIData.MaximumTrainingLevel == 0))
+                    {
+                        npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
+                    }
                 }
             }
         }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,7 +41,7 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    ﻿if (npc.AIData == null || (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0))
+                    ﻿if (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0)
                     {
                         npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
                     }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,10 +41,10 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    ﻿if (npc.AIData != null && npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0)
-                    {
-                        npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
-                    }
+                    //﻿if (npc.AIData == null || (npc.AIData.BuySellServices == 0 && npc.AIData.MaximumTrainingLevel == 0))
+                    //{
+                    //    npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
+                    //}
                 }
             }
         }

--- a/UnleveledOblivion/NPCPatcher.cs
+++ b/UnleveledOblivion/NPCPatcher.cs
@@ -41,7 +41,7 @@ namespace UnleveledOblivion
                     {
                         CalculateNPCLevel(npc, state.LinkCache, isStatic: true, npcLevelsFromFile);
                     }
-                    ﻿if (npc.AIData == null || (Npc.BuySellServiceFlag == 0 && npc.Teaches == 0))
+                    ﻿if (npc.AIData == null || (npc.BuySellServices == 0 && npc.MaximumTrainingLevel == 0))
                     {
                         npc.Configuration.Flags |= Npc.NpcFlag.AutoCalcStats;
                     }


### PR DESCRIPTION
A small fix as suggested by [Darkaxt](https://www.nexusmods.com/oblivion/users/925855) on the [forums](https://forums.nexusmods.com/index.php?/topic/13063218-unleveled-oblivion/page-2#entry126635556).

I tested the change and it appears to work. Training NPCs and Merchants no longer get the "Auto-calc stats" flag set.

This should fix Spell Merchants inventories not appearing and Trainers being unable to train.